### PR TITLE
Fix license information in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ long_description_content_type = text/markdown
 url = https://github.com/swills/py-FreeBSD-ports/
 author = "Steve Wills"
 author_email = "steve@mouf.net"
-license = BSD
+license = BSD-2-Clause
 license_file = LICENSE
 classifiers =
     Development Status :: 3 - Alpha
@@ -17,7 +17,7 @@ classifiers =
     Topic :: Software Development :: Code Generators
     Topic :: Utilities
     Operating System :: POSIX :: BSD :: FreeBSD
-    License :: OSI Approved :: MIT License
+    License :: OSI Approved :: BSD License
     Programming Language :: Python :: 3.6
 
 [options]


### PR DESCRIPTION
1) Use the right license classifier

2) Since the classifier is not precise enough, use an SPDX identifier in
the "license" field.